### PR TITLE
Sugestões para reduzir o Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,12 @@
 FROM ros:melodic-ros-base
 
-RUN apt update \
-    && apt install -y qt5-qmake
-
-RUN echo "ROS_DISTRO=melodic " >> /root/.bashrc
-
-RUN echo "source /opt/ros/melodic/setup.bash" >> /root/.bashrc \
-    && /bin/bash -c "source /root/.bashrc"
+RUN echo "source /opt/ros/melodic/setup.bash" >> /root/.bashrc
 
 RUN mkdir -p /root/catkin_ws/src
 WORKDIR /root/catkin_ws
 RUN /bin/bash -c '. /opt/ros/melodic/setup.bash; cd /root/catkin_ws; catkin_make'
 
+RUN apt update
 
 RUN apt install -y ros-melodic-turtlesim
 


### PR DESCRIPTION
Obrigada pelo exemplo!

Aqui vão algumas sugestões para reduzir um pouco o Dockerfile. Sinta-se à vontade para escolher aquelas com que você concorda.

* Removi a instalação do `qt5-qmake` pois já deve ser dependência do `ros-melodic-turtlesim` e é instalado junto.
* Removi o `ROS_DISTRO` porque ele já é setado pelo `setup.bash`
* Removi o `source /root/.bashrc` porque eu acho que o bash já faz isso automaticamente

Eu testei uma imagem com esse file e o TurtleSim funcionou :wink: 